### PR TITLE
修复cd重置及长度输出问题

### DIFF
--- a/zhenxun_plugin_niuniu/__init__.py
+++ b/zhenxun_plugin_niuniu/__init__.py
@@ -118,7 +118,6 @@ async def _(event: GroupMessageEvent, state: T_State):
       await niuzi_fencing.finish(random.choice(jj_refuse), at_sender=True)
   except KeyError:
     pass
-  group_user_jj[group][qq]['time'] = time.time()
   #
   msg = event.get_message()
   content = readInfo("data/long.json")
@@ -134,6 +133,7 @@ async def _(event: GroupMessageEvent, state: T_State):
         result = "一战多？你的小身板扛得住吗？"
       elif at != qq:
         try:
+          group_user_jj[group][qq]['time'] = time.time()
           opponent_long = de(str(content[group][at]))
           if opponent_long > my_long:
             probability = random.randint(1, 100)
@@ -142,12 +142,12 @@ async def _(event: GroupMessageEvent, state: T_State):
               my_long = my_long - reduce
               if my_long < 0:
                 result = random.choice([
-                  f"哦吼！？看来你的牛子因为击剑而凹进去了呢！凹进去了{reduce}cm！",
-                  f"由于对方击剑技术过于高超，造成你的牛子凹了进去呢！凹进去了深{reduce}cm哦！",
-                  f"好惨啊，本来就不长的牛子现在凹进去了呢！凹进去了{reduce}cm呢！"
+                  f"哦吼！？看来你的牛子因为击剑而凹进去了呢！凹进去了{format(reduce,'.2f')}cm！",
+                  f"由于对方击剑技术过于高超，造成你的牛子凹了进去呢！凹进去了深{format(reduce,'.2f')}cm哦！",
+                  f"好惨啊，本来就不长的牛子现在凹进去了呢！凹进去了{format(reduce,'.2f')}cm呢！"
                 ])
               else:
-                result = f"对方以绝对的长度让你屈服了呢！你的长度减少{reduce}cm，当前长度{my_long}cm！对方增加相应的长度"
+                result = f"对方以绝对的长度让你屈服了呢！你的长度减少{format(reduce,'.2f')}cm，当前长度{format(my_long,'.2f')}cm！对方增加相应的长度"
               opponent_long = opponent_long + reduce
               content[group][qq] = my_long
               content[group][at] = opponent_long
@@ -159,11 +159,11 @@ async def _(event: GroupMessageEvent, state: T_State):
               my_long = my_long + reduce
               if my_long < 0:
                 result = random.choice([
-                  f"哦吼！？你的牛子在长大欸！长大了{reduce}cm！",
-                  f"牛子凹进去的深度变浅了欸！变浅了{reduce}cm！"
+                  f"哦吼！？你的牛子在长大欸！长大了{format(reduce,'.2f')}cm！",
+                  f"牛子凹进去的深度变浅了欸！变浅了{format(reduce,'.2f')}cm！"
                 ])
               else:
-                result = f"虽然你不够长，但是你逆袭了呢！你的长度增加{reduce}cm，当前长度{my_long}cm！对方减少相应的长度"
+                result = f"虽然你不够长，但是你逆袭了呢！你的长度增加{format(reduce,'.2f')}cm，当前长度{format(my_long,'.2f')}cm！对方减少相应的长度"
               content[group][qq] = my_long
               content[group][at] = opponent_long
               readInfo('data/long.json',content)
@@ -176,11 +176,11 @@ async def _(event: GroupMessageEvent, state: T_State):
               my_long = my_long + reduce
               if my_long < 0:
                 result = random.choice([
-                  f"哦吼！？你的牛子在长大欸！长大了{reduce}cm！",
-                  f"牛子凹进去的深度变浅了欸！变浅了{reduce}cm！"
+                  f"哦吼！？你的牛子在长大欸！长大了{format(reduce,'.2f')}cm！",
+                  f"牛子凹进去的深度变浅了欸！变浅了{format(reduce,'.2f')}cm！"
                 ])
               else:
-                result = f"你以绝对的长度让对方屈服了呢！你的长度增加{reduce}cm，当前长度{my_long}cm！对方减少相应的长度"
+                result = f"你以绝对的长度让对方屈服了呢！你的长度增加{format(reduce,'.2f')}cm，当前长度{format(my_long,'.2f')}cm！对方减少相应的长度"
               content[group][qq] = my_long
               content[group][at] = opponent_long
               readInfo('data/long.json',content)
@@ -189,12 +189,12 @@ async def _(event: GroupMessageEvent, state: T_State):
               my_long = my_long - reduce
               if my_long < 0:
                 result = random.choice([
-                  f"哦吼！？看来你的牛子因为击剑而凹进去了呢！目前深度{reduce}cm！",
-                  f"由于对方击剑技术过于高超，造成你的牛子凹了进去呢！当前深度{reduce}cm！",
-                  f"好惨啊，本来就不长的牛子现在凹进去了呢！凹进去了{reduce}cm！"
+                  f"哦吼！？看来你的牛子因为击剑而凹进去了呢！目前深度{format(reduce,'.2f')}cm！",
+                  f"由于对方击剑技术过于高超，造成你的牛子凹了进去呢！当前深度{format(reduce,'.2f')}cm！",
+                  f"好惨啊，本来就不长的牛子现在凹进去了呢！凹进去了{format(reduce,'.2f')}cm！"
                 ])
               else:
-                result = f"虽然你比较长，但是对方逆袭了呢！你的长度减少{reduce}cm，当前长度{my_long}cm！对方增加相应的长度"
+                result = f"虽然你比较长，但是对方逆袭了呢！你的长度减少{format(reduce,'.2f')}cm，当前长度{format(my_long,'.2f')}cm！对方增加相应的长度"
               opponent_long = opponent_long + reduce
               content[group][qq] = my_long
               content[group][at] = opponent_long
@@ -219,47 +219,47 @@ async def _(event: GroupMessageEvent, state: T_State):
   try:
     my_long = content[group][qq]
     if my_long <= -50:
-      result = f"嗯....好像已经穿过了身体吧..从另一面来看也可以算是凸出来的吧?当前深度{my_long}cm"
+      result = f"嗯....好像已经穿过了身体吧..从另一面来看也可以算是凸出来的吧?当前深度{format(my_long,'.2f')}cm"
     elif -50 < my_long <= -25:
       result = random.choice([
-        f"这名女生，你的身体很健康哦！当前深度{my_long}cm",
-        f"WOW,真的凹进去了好多呢！当前深度{my_long}cm",
-        f"你已经是我们女孩子的一员啦！当前深度{my_long}cm"
+        f"这名女生，你的身体很健康哦！当前深度{format(my_long,'.2f')}cm",
+        f"WOW,真的凹进去了好多呢！当前深度{format(my_long,'.2f')}cm",
+        f"你已经是我们女孩子的一员啦！当前深度{format(my_long,'.2f')}cm"
       ])
     elif -25 < my_long <= -10:
       result = random.choice([
-        f"你已经是一名女生了呢，当前深度{my_long}cm",
-        f"从女生的角度来说，你发育良好(,当前深度{my_long}cm",
-        f"你醒啦？你已经是一名女孩子啦！深度足足有{my_long}cm呢！",
-        f"唔....可以放进去一根手指了都....当前深度{my_long}cm"
+        f"你已经是一名女生了呢，当前深度{format(my_long,'.2f')}cm",
+        f"从女生的角度来说，你发育良好(,当前深度{format(my_long,'.2f')}cm",
+        f"你醒啦？你已经是一名女孩子啦！深度足足有{format(my_long,'.2f')}cm呢！",
+        f"唔....可以放进去一根手指了都....当前深度{format(my_long,'.2f')}cm"
       ])
     elif -10 < my_long <= 0:
       result = random.choice([
-        f"安了安了，不要伤心嘛，做女生有什么不好的啊。当前深度{my_long}cm",
-        f"不哭不哭，摸摸头，虽然很难再长出来，但是请不要伤心啦啊！当前深度{my_long}cm",
-        f"加油加油！我看好你哦！当前深度{my_long}cm",
-        f"你醒啦？你现在已经是一名女孩子啦！当前深度{my_long}cm"
+        f"安了安了，不要伤心嘛，做女生有什么不好的啊。当前深度{format(my_long,'.2f')}cm",
+        f"不哭不哭，摸摸头，虽然很难再长出来，但是请不要伤心啦啊！当前深度{format(my_long,'.2f')}cm",
+        f"加油加油！我看好你哦！当前深度{format(my_long,'.2f')}cm",
+        f"你醒啦？你现在已经是一名女孩子啦！当前深度{format(my_long,'.2f')}cm"
       ])
     elif 0 < my_long <= 10:
       result = random.choice([
-        f"你行不行啊？细狗！牛子长度才{my_long}cm！",
-        f"虽然短，但是...emmm....但是虽然短。当前长度{my_long}cm",
-        f"当前牛子长度{my_long}cm！！！"
+        f"你行不行啊？细狗！牛子长度才{format(my_long,'.2f')}cm！",
+        f"虽然短，但是...emmm....但是虽然短。当前长度{format(my_long,'.2f')}cm",
+        f"当前牛子长度{format(my_long,'.2f')}cm！！！"
       ])
     elif 10 < my_long <= 25:
       result = random.choice([
-        f"唔，当前牛子长度是{my_long}cm",
-        f"已经很长呢！当前长度{my_long}cm"
+        f"唔，当前牛子长度是{format(my_long,'.2f')}cm",
+        f"已经很长呢！当前长度{format(my_long,'.2f')}cm"
       ])
     elif 25 < my_long <= 50:
       result = random.choice([
-        f"话说这种真的有可能吗？当前牛子长度{my_long}cm",
-        f"牛子长度居然是{my_long}cm呢！！！"
+        f"话说这种真的有可能吗？当前牛子长度{format(my_long,'.2f')}cm",
+        f"牛子长度居然是{format(my_long,'.2f')}cm呢！！！"
       ])
     elif 50 < my_long:
       result = random.choice([
-        f"已经突破天际了嘛...当前牛子长度{my_long}cm",
-        f"唔...这玩意应该不会变得比我高吧？当前牛子长度{my_long}cm"
+        f"已经突破天际了嘛...当前牛子长度{format(my_long,'.2f')}cm",
+        f"唔...这玩意应该不会变得比我高吧？当前牛子长度{format(my_long,'.2f')}cm"
       ])
   except KeyError:
     result = "你还没有牛子呢！"
@@ -337,8 +337,8 @@ async def _(event: GroupMessageEvent, state: T_State):
       await niuzi_hit_glue.finish(random.choice(glue_refuse), at_sender=True)
   except KeyError:
     pass
-  group_hit_glue[group][qq]['time'] = time.time()
   try:
+    group_hit_glue[group][qq]['time'] = time.time()
     content = readInfo("data/long.json")
     my_long = de(str(content[group][qq]))
     probability = random.randint(1, 100)
@@ -346,8 +346,8 @@ async def _(event: GroupMessageEvent, state: T_State):
       reduce = random_long()
       my_long = my_long + reduce
       result = random.choice([
-        f"你的打胶促进了牛子发育，牛子增加{reduce}cm了呢！",
-        f"你的牛子在众人震惊的目光下增加了{reduce}cm呢！"
+        f"你的打胶促进了牛子发育，牛子增加{format(reduce,'.2f')}cm了呢！",
+        f"你的牛子在众人震惊的目光下增加了{format(reduce,'.2f')}cm呢！"
         ])
     elif 40 < probability <= 60:
       result = random.choice([
@@ -359,13 +359,13 @@ async def _(event: GroupMessageEvent, state: T_State):
       my_long = my_long - reduce
       if my_long < 0:
         result = random.choice([
-          f"哦吼！？看来你的牛子凹进去了{reduce}cm呢！",
-          f"你因为打胶过度导致牛子凹了进去{reduce}cm呢！"
+          f"哦吼！？看来你的牛子凹进去了{format(reduce,'.2f')}cm呢！",
+          f"你因为打胶过度导致牛子凹了进去{format(reduce,'.2f')}cm呢！"
         ])
       else:
         result = random.choice([
-          f"阿哦，你过度打胶，牛子缩短{reduce}cm了呢！",
-          f"你的牛子变长了很多，你很激动地继续打胶，造成牛子不但没增加还缩短{reduce}cm了呢！"
+          f"阿哦，你过度打胶，牛子缩短{format(reduce,'.2f')}cm了呢！",
+          f"你的牛子变长了很多，你很激动地继续打胶，造成牛子不但没增加还缩短{format(reduce,'.2f')}cm了呢！"
           ])
     content[group][qq] = my_long
     readInfo('data/long.json',content)


### PR DESCRIPTION
- 修复 击剑和打胶失败后依然重置cd问题，改为仅成功后重置
- 将牛牛长度输出统一规定两位小数，避免位数过多影响观感