### PR TITLE
增加定时重置用户长度数据

### DIFF
--- a/zhenxun_plugin_niuniu/__init__.py
+++ b/zhenxun_plugin_niuniu/__init__.py
@@ -1,3 +1,4 @@
+from nonebot import require
 from nonebot import on_command
 from nonebot.params import CommandArg
 from utils.utils import is_number
@@ -43,11 +44,17 @@ niuzi_my = on_command("我的牛子", priority=5, block=True)
 niuzi_ranking = on_command("牛子长度排行", priority=5, block=True)
 niuzi_ranking_e = on_command("牛子深度排行", priority=5, block=True)
 niuzi_hit_glue = on_command("打胶", priority=5, block=True)
+scheduler = require("nonebot_plugin_apscheduler").scheduler#定时任务
 
 group_user_jj = {}
 group_hit_glue = {}
 
 path = os.path.dirname(__file__)
+
+#定时重置数据
+@scheduler.scheduled_job("cron", hour=0, minute=0)
+async def daily_reset():
+    reset_long_json()
 
 if not os.path.exists(f"{path}/data"):
     os.makedirs(f"{path}/data")

--- a/zhenxun_plugin_niuniu/data_source.py
+++ b/zhenxun_plugin_niuniu/data_source.py
@@ -14,6 +14,12 @@ from typing import List, Union
 
 path = os.path.dirname(__file__)
 
+def reset_long_json():
+    path = os.path.dirname(__file__)
+    with open(os.path.join(path, "data/long.json"), "w", encoding="utf-8") as f:
+        f.write('{}')
+    print("long.json has been reset.")
+
 def pic2b64(pic: Image) -> str:
     """
     说明:


### PR DESCRIPTION
通过调整触发器的参数设定不同的周期
每小时重置@scheduler.scheduled_job("cron", minute=0)
每周一重置@scheduler.scheduled_job("cron", day_of_week='mon', hour=0, minute=0)
每月重置@scheduler.scheduled_job("cron", day=1, hour=0, minute=0)
每隔30分钟重置@scheduler.scheduled_job("interval", minutes=30)