### PR TITLE
Bug-fix/tomatoo

### DIFF
--- a/niuniu/events.yaml
+++ b/niuniu/events.yaml
@@ -50,7 +50,7 @@ glue_events:
 
   shrinkage:
     weight: 10
-    positive_descriptions:
+    negative_descriptions:
       - "由于你在换蛋期打胶，你的牛牛断掉了呢！当前长度{new_length}cm!🤯"
       - "bro换蛋期就不要打胶了！你的牛牛萎缩了{diff}cm！💩"
     effect: 0.5

--- a/niuniu/events.yaml
+++ b/niuniu/events.yaml
@@ -5,8 +5,8 @@ glue_events:
       - "你嘿咻嘿咻一下，促进了牛牛发育，牛牛增加了{diff}cm了呢！🎉"
       - "你打了个舒服痛快的🦶呐，牛牛增加了{diff}cm呢！💪"
       - "哇哦！你的一🦶让牛牛变长了{diff}cm！👏"
-      - "你的牛牛感受到了你的热情，增长了{diff}cm！🔥"
-      - "你的一脚仿佛有魔力，牛牛增长了{diff}cm！✨"
+      - "你的牛牛感受到了你的热情，增加了{diff}cm！🔥"
+      - "你的一脚仿佛有魔力，牛牛增加了{diff}cm！✨"
     no_change_descriptions:
       - "你打了个🦶，但是什么变化也没有，好奇怪捏~🤷‍♂️"
       - "你的牛牛刚开始变长了，可过了一会又回来了，什么变化也没有，好奇怪捏~🤷‍♀️"
@@ -78,7 +78,6 @@ glue_events:
       - "这么着急？牛牛只微微增长了{diff}cm...🤏"
       - "bro你搞这么快只会适得其反！牛牛只增加{diff}cm！😰"
     negative_descriptions:
-      - "这么着急？牛牛却减少了{diff}cm...😢"
+      - "这么着急？牛牛减少了{diff}cm...😢"
       - "bro你搞这么快只会适得其反！牛牛减少了{diff}cm！😭"
-    effect: 0.9
-    category: "growth"
+    category: "reduce"

--- a/niuniu/fence.py
+++ b/niuniu/fence.py
@@ -90,7 +90,7 @@ class Fencing:
         adjusted_p_a = p_a - reduction
 
         # 返回调整后的胜率
-        return max(adjusted_p_a, 0.01)
+        return max(adjusted_p_a, 0.10)
 
     @classmethod
     async def apply_skill(cls, my, oppo, increase_length, uid):

--- a/niuniu/niuniu.py
+++ b/niuniu/niuniu.py
@@ -114,7 +114,7 @@ class NiuNiu:
 
     @classmethod
     async def gluing(
-        cls, origin_length: float, discount: float = 1
+        cls, origin_length: float, discount: float = 1, reduce: bool = False
     ) -> tuple[float, float]:
         result = await cls.get_nearest_lengths(origin_length)
         if result[0] != 0 and result[1] != 0:
@@ -130,6 +130,8 @@ class NiuNiu:
             diff = prob * 0.1 * origin_length * -1
         else:
             diff = prob * 0.1 * origin_length
+        if reduce:
+            diff = diff * -1
         raw_new_length = origin_length + diff * discount
         new_length = await cls.apply_decay(raw_new_length)
         return round(new_length, 2), round(new_length - origin_length, 2)

--- a/niuniu/niuniu_goods/event_manager.py
+++ b/niuniu/niuniu_goods/event_manager.py
@@ -114,14 +114,14 @@ async def process_glue_event(
         #     )
         #     return result, new_length, diff
 
-        desc_template = choose_description(
+        desc_template, need_abs = choose_description(
             diff,
             event.positive_descriptions,
             event.negative_descriptions,
             event.no_change_descriptions,
         )
         result = desc_template.format(
-            diff=round(abs(diff), 2),
+            diff=round(abs(diff) if need_abs else diff, 2),
             new_length=round(new_length, 2),
             ban_time=event.ban_time,
         )

--- a/niuniu/niuniu_goods/event_manager.py
+++ b/niuniu/niuniu_goods/event_manager.py
@@ -35,10 +35,10 @@ def choose_description(
     if diff > 0 and positive_descs:
         return random.choice(positive_descs), False
     elif diff < 0 and negative_descs:
-        return random.choice(negative_descs), False
+        return random.choice(negative_descs), True
     elif diff == 0 and no_change_descs:
         return random.choice(no_change_descs), False
-    return random.choice(positive_descs or negative_descs or ["无描述"]), True
+    return random.choice(positive_descs or negative_descs or ["无描述"]), False
 
 
 async def process_glue_event(
@@ -77,14 +77,14 @@ async def process_glue_event(
             new_length = origin_length
             diff = 0
 
-        desc_template, no_abs = choose_description(
+        desc_template, need_abs = choose_description(
             diff,
             rapid_effect.positive_descriptions,
             rapid_effect.negative_descriptions,
             rapid_effect.no_change_descriptions,
         )
         result = desc_template.format(
-            diff=round(diff if no_abs else abs(diff), 2),
+            diff=round(abs(diff) if need_abs else diff, 2),
             new_length=round(new_length, 2),
             ban_time=rapid_effect.ban_time,
         )


### PR DESCRIPTION
- 修改 choose_description 函数，修复了无变化时描述模板的选择逻辑
- 更新 process_glue_event 和 process_ban_event 函数，根据新逻辑处理描述模板
- 优化了描述模板的变量命名，提高了代码可读性

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

改进了 NiuNiu 游戏中 glue 事件的描述模板选择和处理逻辑，增强了事件处理和描述生成。

新特性：
- 在 glue 事件中增加了对新的 'reduce' 事件类别的支持
- 引入了一种机制，用于在描述格式化中有条件地使用绝对值

Bug 修复：
- 修复了在 `choose_description` 函数中没有发生变化时的描述模板选择逻辑
- 修正了事件描述中正负长度变化的错误处理

增强：
- 修改了 `choose_description` 函数，使其返回描述和一个指示绝对值使用的标志
- 更新了事件处理，以更精确地处理不同的事件类别
- 改进了变量命名，以提高代码可读性

<details>
<summary>Original summary in English</summary>

好的，这是将拉取请求总结翻译成中文的结果：

## Sourcery 总结

改进了牛牛游戏事件的描述模板选择和事件处理逻辑，增强了事件处理和描述生成能力。

新特性：
- 在 glue events 中添加了对新的 'reduce' 事件类别的支持

Bug 修复：
- 修复了未发生更改时描述模板选择逻辑的问题
- 修正了事件描述中正负长度变化的错误处理

增强：
- 修改了 `choose_description` 函数，使其返回描述和绝对值使用标志
- 更新了事件处理，以更精确地处理不同的事件类别
- 改进了变量命名，以提高代码可读性

测试：
- 将获胜概率计算的最小阈值从 0.01 调整为 0.10

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the description template selection and event processing logic for NiuNiu game events, enhancing event handling and description generation

New Features:
- Add support for a new 'reduce' event category in glue events

Bug Fixes:
- Fix description template selection logic when no changes occur
- Correct handling of positive and negative length changes in event descriptions

Enhancements:
- Modify choose_description function to return description and absolute value usage flag
- Update event processing to handle different event categories more precisely
- Improve variable naming for better code readability

Tests:
- Adjust win probability calculation minimum threshold from 0.01 to 0.10

</details>

</details>