### PR TITLE
fix(niuniu_goods): 修复轮胎尺寸计算逻辑

### DIFF
--- a/niuniu/niuniu_goods/event_manager.py
+++ b/niuniu/niuniu_goods/event_manager.py
@@ -71,7 +71,7 @@ async def process_glue_event(
                 origin_length, rapid_effect.coefficient
             )
         elif rapid_effect.effect:
-            new_length = round(origin_length * rapid_effect.effect, 2)
+            new_length = round(abs(origin_length) * rapid_effect.effect, 2)
             diff = new_length - origin_length
         else:
             new_length = origin_length
@@ -95,7 +95,7 @@ async def process_glue_event(
         elif event.category == "reduce":
             new_length, diff = await NiuNiu.gluing(origin_length, reduce=True)
         elif event.category == "shrinkage":
-            new_length = round(origin_length * event.effect, 2)
+            new_length = round(abs(origin_length) * event.effect, 2)
             diff = new_length - origin_length
         elif event.category == "arrested":
             new_length = origin_length


### PR DESCRIPTION
- 在处理快速效果和收缩事件时，添加了对原始尺寸的绝对值计算
- 确保轮胎尺寸在计算时不会出现负值
- resolve [BUG]打胶断裂事件错误处理负数牛牛 #39

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 修复了在快速效果和收缩事件期间出现负轮胎尺寸的问题，通过使用原始长度的绝对值来避免。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent negative tire sizes during rapid effect and shrinkage events by using absolute value of origin length

</details>