### PR TITLE
个人面板显示buff信息，修复buff不生效问题

### DIFF
--- a/niuniu/__init__.py
+++ b/niuniu/__init__.py
@@ -42,7 +42,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="1.2.rc1",
+        version="1.2.rc2",
         menu_type="群内小游戏",
     ).dict(),
 )

--- a/niuniu/data_source.py
+++ b/niuniu/data_source.py
@@ -1,6 +1,7 @@
 import random
 
-from nonebot import get_bot
+from nonebot import get_bot, require
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_uninfo import Uninfo
 from tortoise.functions import Max, Min
 

--- a/niuniu/fence.py
+++ b/niuniu/fence.py
@@ -1,6 +1,7 @@
 import random
 import time
-
+from nonebot import require
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_uninfo import Uninfo
 
 from zhenxun.configs.config import BotConfig

--- a/niuniu/model.py
+++ b/niuniu/model.py
@@ -9,11 +9,11 @@ from zhenxun.services.db_context import Model
 class NiuNiuUser(Model):
     id = fields.IntField(pk=True, generated=True, auto_increment=True)
     """自增id"""
-    uid = fields.TextField(description="用户唯一标识符")
+    uid = fields.CharField(255, description="用户唯一标识符")
     """用户id"""
     length = fields.FloatField(description="用户长度")
     """用户长度"""
-    sex = fields.TextField(description="用户性别", default="boy")
+    sex = fields.CharField(255, description="用户性别", default="boy")
     """用户性别"""
     time = fields.DatetimeField(auto_now_add=True)
     """创建时间"""

--- a/niuniu/niuniu.py
+++ b/niuniu/niuniu.py
@@ -1,6 +1,7 @@
 import random
 
-from nonebot import get_bot
+from nonebot import get_bot, require
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_uninfo import Uninfo
 from tortoise.functions import Max, Min
 

--- a/niuniu/niuniu_goods/event_manager.py
+++ b/niuniu/niuniu_goods/event_manager.py
@@ -149,7 +149,6 @@ async def get_buffs(uid: str) -> PropModel:
     :return: 用户的 buff 信息（未过期）或 None
     """
     # 获取 buff 信息
-    uid = str(uid)
     buff_info = await UserState.get("buff_map", uid)
 
     # 如果 buff 存在且未过期

--- a/niuniu/niuniu_goods/event_manager.py
+++ b/niuniu/niuniu_goods/event_manager.py
@@ -122,7 +122,7 @@ async def use_prop(uid: str, prop_name: str) -> str:
     # 更新道具状态
     await UserState.update("buff_map", uid, prop)
 
-    return f"使用了 {prop.name}，效果持续至 {time.ctime(expire_time)}"
+    return f"使用了 {prop.name}，效果持续至 {time.ctime(prop.expire_time)}"
 
 
 async def adjust_glue_effects(uid: str) -> dict[str, GlueEvent]:
@@ -149,6 +149,7 @@ async def get_buffs(uid: str) -> PropModel:
     :return: 用户的 buff 信息（未过期）或 None
     """
     # 获取 buff 信息
+    uid = str(uid)
     buff_info = await UserState.get("buff_map", uid)
 
     # 如果 buff 存在且未过期

--- a/niuniu/shop.py
+++ b/niuniu/shop.py
@@ -1,4 +1,6 @@
 import time
+from nonebot import require
+require("nonebot_plugin_uninfo")
 
 from nonebot_plugin_uninfo import Uninfo
 

--- a/niuniu/templates/my_info.html
+++ b/niuniu/templates/my_info.html
@@ -1,70 +1,85 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NiuNiu Info</title>
-    <style>
-      .card {
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        margin: 20px;
-        padding: 20px;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-        background-color: #ffffff;
-      }
-      .card-header {
-        display: flex;
-        align-items: center;
-        margin-bottom: 15px;
-      }
-      .card-header img {
-        width: 30px;
-        height: 30px;
-        border-radius: 50%;
-        margin-right: 10px;
-      }
-      .card-header .title {
-        font-size: 18px;
-        font-weight: bold;
-      }
-      .male {
-        color: blue;
-      }
-      .female {
-        color: pink;
-      }
-      .negative-length {
-        color: red;
-      }
-      .positive-length {
-        color: green;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="card">
-      <div class="card-header">
-        <img src="{{ avatar }}" alt="{{ name }}" />
-        <span class="title">{{ name }}の牛牛信息</span>
-      </div>
-      <p><span>排名:</span><b> #{{ rank }}</b></p>
-      <p>
-        <span>性别:</span>
-        <span class="{{ 'male' if my_length > 0 else 'female' }}">
-          {{ '♂️' if my_length > 0 else '♀️' }}
-        </span>
-      </p>
-      <p>
-        <span>{{ '深' if my_length < 0 else '长' }}度:</span>
-        <span
-          class="{{ 'negative-length' if my_length < 0 else 'positive-length' }}"
-        >
-          {{ my_length | abs if my_length < 0 else my_length }}cm
-        </span>
-      </p>
-      <p><span>上次打胶时间:</span> {{ latest_gluing_time }}</p>
-      <p><span>备注:</span> {{ comment }}</p>
-    </div>
-  </body>
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>NiuNiu Character Card</title>
+	<style>
+		body {
+		  background-color: #f5f5f5;
+		}
+		.card {
+		  display: flex;
+		  flex-direction: row;
+		  border-radius: 12px;
+		  padding: 20px;
+		  margin: 10px;
+		  background: #ffffff;
+		  max-width: 650px;
+		  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+		}
+		.card-header {
+		  display: flex;
+		  align-items: center;
+		  margin-bottom: 15px;
+		}
+		.card-header img {
+		  width: 30px;
+		  height: 30px;
+		  border-radius: 50%;
+		  margin-right: 10px;
+		}
+		.title {
+		  font-size: 18px;
+		  font-weight: bold;
+		}
+		.info {
+		  flex: 2;
+		  display: flex;
+		  max-width: 500px;
+		  flex-direction: column;
+		}
+		.buffs {
+		  flex: 1;
+		  border-left: 2px solid #ccc;
+		  padding-left: 15px;
+		}
+		.buff-positive, .length-positive {
+		  color: #4caf50;
+		  font-weight: bold;
+		}
+		.buff-negative, .length-negative {
+		  color: #e53935;
+		  font-weight: bold;
+		}
+	</style>
+</head>
+<body>
+	<div class="card">
+		<div class="info">
+			<div class="card-header">
+				<img src="{{ avatar }}" alt="{{ name }}" />
+				<span class="title">{{ name }}の牛牛信息</span>
+			</div>
+			<span><b>排名:</b> #{{ rank }}</span><br>
+			<span><b>性别:</b> {{ '♂️' if my_length > 0 else '♀️' }}</span><br>
+			<span>
+				<b>{{ '深' if my_length < 0 else '长' }}度:</b>
+				<span class="{{ 'length-negative' if my_length < 0 else 'length-positive' }}"> {{ my_length | abs if my_length < 0 else my_length }}cm </span>
+			</span><br>
+			<span><b>上次打胶时间:</b> {{ latest_gluing_time }}</span><br>
+			<span><b>备注:</b> {{ comment }}</span><br>
+		</div>
+		{% if buff.name != "None" %}
+		<div class="buffs">
+			<span class="title">Buff 状态</span>
+			<p class="{{ 'buff-positive' if buff.glue_effect > 1 else 'buff-negative' }}"><b>{{ buff.name }}</b></p>
+			<p><b>击剑胜率倍率:</b> x{{ buff.fencing_weight }}</p>
+			<p><b>打胶倍率:</b> x{{ buff.glue_effect }}</p>
+			<p><b>负面事件倍率:</b> x{{ buff.glue_negative_weight }}</p>
+			<p><b>⏳ 剩余时间:</b> {{ (buff.expire_time - now) | round(1) }}s</p>
+		</div>
+		{% endif %}
+	</div>
+</body>
 </html>


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在优化 UI 和更新数据模型的同时，在个人面板上显示激活的 Buff，并解决阻止 Buff 正确应用和显示的问题。

新功能：
- 在用户个人信息卡上显示 Buff 信息，包括效果和剩余时间

Bug 修复：
- 修复 Buff 检索，通过将 UID 规范化为字符串，更正 Buff 消息中的过期时间，并调整头像获取以接受字符串 UID

增强功能：
- 改进个人信息面板布局和 CSS，采用双栏卡片样式
- 将 NiuNiuUser 的 UID 和 sex 字段更改为 CharField，以与字符串 ID 对齐

日常维护：
- Bump plugin version from 1.2.rc1 to 1.2.rc2

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show active buffs on the personal panel and resolve issues preventing buffs from applying and displaying correctly while polishing the UI and updating the data model.

New Features:
- Display buff information with effects and remaining time on the user’s personal info card

Bug Fixes:
- Fix buff retrieval by normalizing UID to string, correct expiration time in buff messages, and adjust avatar fetch to accept string UID

Enhancements:
- Revamp personal info panel layout and CSS for a two-column card style
- Change NiuNiuUser UID and sex fields to CharField to align with string IDs

Chores:
- Bump plugin version from 1.2.rc1 to 1.2.rc2

</details>